### PR TITLE
chore: ajouter un pattern de PR (pull_request_template.md)

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Pattern de PR pour ce depot. Remplace chaque section avant de publier,
+supprime ce commentaire.
+
+Titre de la PR : <type>: <resume court a l'imperatif>
+Types : feat, fix, fix(security), chore, docs, refactor
+Exemples :
+  fix(security): proteger create-playlist et sync-playlists par requireAuth+requireAdmin
+  feat: fondu d'entree et de sortie sur les extraits audio
+-->
+
+## Contexte
+
+<!-- Pourquoi ce changement est necessaire : le probleme observe, pas seulement ce qui a change. -->
+
+## Changements
+
+<!-- Liste a puces des modifications, fichier par fichier si utile. -->
+
+-
+
+## Verifications
+
+<!-- Ce qui a ete teste/valide (build, node --check, test manuel...), et ce qui NE l'a PAS ete (ex : pas de .env pour tester en conditions reelles). -->
+
+-
+
+## Notes
+
+<!-- Decisions volontairement hors perimetre, risques de conflit connus avec d'autres branches, dependances entre PR. -->


### PR DESCRIPTION
Standardise le format des descriptions de PR (Contexte / Changements / Verifications / Notes) pour que chaque PR explique le probleme resolu, pas seulement le diff. Place a la racine du depot : GitHub le detecte nativement a cet emplacement (comme .github/) et pre-remplit la description de toute nouvelle PR ouverte depuis l'UI.