### PR TITLE
fix: reconnecter le moteur de jeu a l'architecture Supabase

### DIFF
--- a/back/controllers/music.controller.js
+++ b/back/controllers/music.controller.js
@@ -43,21 +43,6 @@ class MusicController {
         }
     }
 
-
-
-
-
-
-    //////////////////////////////////////////// plAYER
-    async getCategories(req, res) {
-        try {
-            const data = await MusicService.getCategories();
-            res.json(data);
-        } catch (error) {
-            console.error('Failed to fetch categories:', error);
-            res.status(500).json({ error: "Failed to fetch categories" });
-        }
-    }
 }
 
 module.exports = new MusicController();

--- a/back/routes/music.routes.js
+++ b/back/routes/music.routes.js
@@ -2,11 +2,6 @@ const express = require('express');
 const router = express.Router();
 const MusicController = require('../controllers/music.controller');
 
-// GET /api/music/get-categories (maybe deprecated)
-router.get('/get-categories', MusicController.getCategories);
-
-
-
 // GET /api/music/list-playlists
 router.get('/list-playlists', MusicController.ListPlaylist)
 

--- a/back/services/game.service.js
+++ b/back/services/game.service.js
@@ -11,13 +11,10 @@ class GameService {
         const category = room.setting.category;
         const nbMusics = room.setting.songCount;
 
-        // Extract playlistId from tracklist URL (e.g., /playlists/37i9dQZF1DXcBWIGoYBM5M/tracks)
-        const playlistId = category.tracklist.split('/')[2];
-        
-        let allTracks = await MusicService.getPlaylistTracks(playlistId);
-        
+        const playlistDetails = await MusicService.GetPlaylistDetails(category.id);
+
         // Shuffle and take required number
-        allTracks = allTracks.sort(() => Math.random() - 0.5).slice(0, nbMusics);
+        let allTracks = (playlistDetails.songs || []).sort(() => Math.random() - 0.5).slice(0, nbMusics);
 
         room.players.forEach(player => {
             player.titleGuessed = false;

--- a/back/services/music.service.js
+++ b/back/services/music.service.js
@@ -273,22 +273,6 @@ class SpotifyService {
 
         return response.json();
     }
-
-    async getCategories() {
-        // En Spotify, on peut récupérer des playlists de catégories ou des playlists "featured"
-        // Pour correspondre à l'ancienne logique Deezer (charts), on va chercher des playlists populaires
-        const data = await this.fetchFromSpotify('/browse/featured-playlists?limit=20');
-        return {
-            playlists: {
-                data: data.playlists.items.map(item => ({
-                    id: item.id,
-                    title: item.name,
-                    picture_big: item.images[0]?.url,
-                    tracklist: `/playlists/${item.id}/tracks`
-                }))
-            }
-        };
-    }
 }
 
 module.exports = new SpotifyService();

--- a/front/src/components/Blindtest/Room/Utils/BlindtestCategories.vue
+++ b/front/src/components/Blindtest/Room/Utils/BlindtestCategories.vue
@@ -25,11 +25,11 @@ onMounted(async () => {
     if (playerStore.categories.length > 0) return;
     try {
         const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
-        const response = await fetch(`${apiUrl}/api/music/get-categories`);
+        const response = await fetch(`${apiUrl}/api/music/list-playlists`);
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
         const data = await response.json();
-        if (data?.playlists?.data) {
-            playerStore.setCategories(data.playlists.data);
+        if (Array.isArray(data)) {
+            playerStore.setCategories(data);
         }
     } catch (error) {
         console.error('Failed to fetch categories:', error.message);
@@ -60,8 +60,8 @@ onMounted(async () => {
     <div v-else class="blindtest-categories w50 u-flex-direction-column u-flex u-justify-content-center u-align-items-center u-gap20 u-p10">
         <h2 v-if="hostPlayer" class="t-body-text t-color-white t-align-center">{{ hostPlayer.username }} is setting up the game...</h2>
         <div v-if="room.setting.category" class="selected-category-preview u-flex-direction-column u-align-items-center u-gap15">
-            <img :src="room.setting.category.picture_big" alt="Waiting for host" class="img-category">
-            <p class="category-name t-body-text">{{ room.setting.category.title }}</p>
+            <img :src="room.setting.category.cover_url" alt="Waiting for host" class="img-category">
+            <p class="category-name t-body-text">{{ room.setting.category.name }}</p>
         </div>
     </div>
 </template>

--- a/front/src/components/Blindtest/Room/Utils/Category.vue
+++ b/front/src/components/Blindtest/Room/Utils/Category.vue
@@ -29,7 +29,7 @@ function selectCategory() {
 <template>
     <div @click="selectCategory" class="category u-flex u-flex-direction-column u-align-items-center u-justify-content-center u-gap10" :class="{ selected: isSelected }">
         <div class="opacity-filter"></div>
-        <img :src="category.picture_big" alt="">
+        <img :src="category.cover_url" :alt="category.name">
     </div>
 </template>
 


### PR DESCRIPTION
startGame appelait MusicService.getPlaylistTracks (pensee pour le sync admin, exige un token Spotify jamais fourni -> 401 systematique) au lieu de GetPlaylistDetails qui lit les morceaux deja synchronises en base (avec preview_url resolu). Le front consommait aussi l'endpoint Spotify get-categories (champs title/picture_big) plutot que list-playlists (Supabase, champs name/cover_url) ; endpoint devenu mort supprime (route + controller + service).