### PR TITLE
fix(security): proteger create-playlist et sync-playlists par require…

### DIFF
--- a/back/middleware/admin.js
+++ b/back/middleware/admin.js
@@ -2,7 +2,7 @@ const profileRepository = require('../repositories/profile.repository');
 
 const requireAdmin = async (req, res, next) => {
     try {
-        const profile = await profileRepository.findByIdWithRole(req.user.sub);
+        const profile = await profileRepository.findByIdWithRole(req.user.id);
 
         if (profile?.roles?.role !== 'Admin') {
             return res.status(403).json({ error: 'Forbidden' });

--- a/back/routes/music.routes.js
+++ b/back/routes/music.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const MusicController = require('../controllers/music.controller');
+const { requireAuth } = require('../middleware/auth');
+const requireAdmin = require('../middleware/admin');
 
 // GET /api/music/get-categories (maybe deprecated)
 router.get('/get-categories', MusicController.getCategories);
@@ -14,9 +16,9 @@ router.get('/list-playlists', MusicController.ListPlaylist)
 router.get('/get-playlist-details/:id', MusicController.GetPlaylistDetails)
 
 // POST  /api/music/create-playlist
-router.post('/create-playlist', MusicController.createPlaylist)
+router.post('/create-playlist', requireAuth, requireAdmin, MusicController.createPlaylist)
 
 // GET /api/music/sync-playlists
-router.get('/sync-playlists', MusicController.SyncPlaylists)
+router.get('/sync-playlists', requireAuth, requireAdmin, MusicController.SyncPlaylists)
 
 module.exports = router;

--- a/front/src/views/admin/Backoffice.vue
+++ b/front/src/views/admin/Backoffice.vue
@@ -3,8 +3,10 @@ import SoundVolume from '@/components/Blindtest/Game/Utils/SoundVolume.vue'
 import PlaylistListPanel from '@/components/Admin/PlaylistListPanel.vue'
 import PlaylistDetailPanel from '@/components/Admin/PlaylistDetailPanel.vue'
 import { ref, onMounted, watch } from 'vue'
+import { useAuthStore } from '@/stores/authStore'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const authStore = useAuthStore()
 
 const playlists = ref([])
 const selectedPlaylist = ref(null)
@@ -66,7 +68,9 @@ async function syncPlaylists() {
     syncMessage.value = null
 
     try {
-        const response = await fetch(`${API_URL}/api/music/sync-playlists`)
+        const response = await fetch(`${API_URL}/api/music/sync-playlists`, {
+            headers: { Authorization: `Bearer ${authStore.token}` }
+        })
         if (!response.ok) {
             throw new Error(`Statut de réponse : ${response.status}`)
         }


### PR DESCRIPTION
…Auth+requireAdmin

back/routes/music.routes.js n'appliquait aucun middleware : n'importe qui pouvait declencher une synchronisation Spotify ou creer une playlist sans etre authentifie. Le middleware admin.js existait mais n'etait branche nulle part, et contenait par ailleurs un bug qui l'aurait rendu inoperant (req.user.sub au lieu de req.user.id -- la reponse de supabase.auth.getUser() n'expose pas de champ "sub").

- middleware/admin.js : utilise req.user.id (ce que verifyToken pose reellement sur req.user), pas req.user.sub.
- routes/music.routes.js : requireAuth + requireAdmin sur POST /create-playlist et GET /sync-playlists.
- Backoffice.vue : le bouton de sync doit desormais envoyer le token d'auth, sinon l'admin lui-meme se fait rejeter par le nouveau garde.

list-playlists et get-playlist-details restent publics en lecture : list-playlists est aussi consomme par les joueurs (choix de playlist en jeu) sans session admin, et get-playlist-details ne renvoie que des metadonnees de morceaux deja publiques via list-playlists. Les proteger necessiterait de revoir ce flux cote jeu, hors perimetre de ce correctif.