### PR TITLE
fix: limiter le pseudo a 20 caracteres, valide cote serveur

### DIFF
--- a/back/controllers/profile.controller.js
+++ b/back/controllers/profile.controller.js
@@ -1,0 +1,15 @@
+const ProfileService = require('../services/profile.service');
+
+class ProfileController {
+    async updateMe(req, res) {
+        try {
+            const profile = await ProfileService.updateProfile(req.user.id, req.body);
+            res.json(profile);
+        } catch (error) {
+            console.error('Failed to update profile:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+}
+
+module.exports = new ProfileController();

--- a/back/repositories/profile.repository.js
+++ b/back/repositories/profile.repository.js
@@ -18,6 +18,22 @@ class ProfileRepository {
         if (error) throw error;
         return data;
     }
+
+    async updateProfile(userId, { username, avatar_url }) {
+        const { data, error } = await supabase
+            .from('profiles')
+            .upsert({
+                id: userId,
+                username,
+                avatar_url,
+                updated_at: new Date().toISOString()
+            })
+            .select('username, avatar_url')
+            .single();
+
+        if (error) throw error;
+        return data;
+    }
 }
 
 module.exports = new ProfileRepository();

--- a/back/routes/profile.routes.js
+++ b/back/routes/profile.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const ProfileController = require('../controllers/profile.controller');
+const { requireAuth } = require('../middleware/auth');
+
+// PATCH /api/profile/me
+router.patch('/me', requireAuth, (req, res) => ProfileController.updateMe(req, res));
+
+module.exports = router;

--- a/back/server.js
+++ b/back/server.js
@@ -10,6 +10,7 @@ const { PORT, CLIENT_URL } = require('./config/constants');
 const { corsOptions } = require('./config/cors');
 const musicRoutes = require('./routes/music.routes');
 const authRoutes = require('./routes/auth.routes');
+const profileRoutes = require('./routes/profile.routes');
 const setupSocketIO = require('./sockets/connection');
 
 const app = express();
@@ -29,6 +30,7 @@ app.use(express.json());
 // REST routes
 app.use('/api/auth', authRoutes);
 app.use('/api/music', musicRoutes);
+app.use('/api/profile', profileRoutes);
 
 
 

--- a/back/services/profile.service.js
+++ b/back/services/profile.service.js
@@ -1,0 +1,27 @@
+const profileRepository = require('../repositories/profile.repository');
+
+const USERNAME_MAX_LENGTH = 20;
+
+class ProfileService {
+    async updateProfile(userId, { username, avatar_url }) {
+        const trimmedUsername = (username ?? '').trim();
+
+        if (trimmedUsername === '') {
+            const error = new Error('Le pseudo ne peut pas être vide.');
+            error.status = 400;
+            throw error;
+        }
+        if (trimmedUsername.length > USERNAME_MAX_LENGTH) {
+            const error = new Error(`Le pseudo ne doit pas dépasser ${USERNAME_MAX_LENGTH} caractères.`);
+            error.status = 400;
+            throw error;
+        }
+
+        return await profileRepository.updateProfile(userId, {
+            username: trimmedUsername,
+            avatar_url: avatar_url || null
+        });
+    }
+}
+
+module.exports = new ProfileService();

--- a/front/src/views/profile/Dashboard.vue
+++ b/front/src/views/profile/Dashboard.vue
@@ -6,6 +6,7 @@ import ParticleBackground from "@/components/Basics/ParticleBackground.vue";
 import { ref, onMounted, computed } from 'vue';
 import { supabase } from '@/services/supabase';
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 const authStore = useAuthStore();
 const toastStore = useToastStore();
 const user = computed(() => authStore.user);
@@ -58,27 +59,47 @@ async function fetchProfile() {
     }
 }
 
+function limitUsernameLength() {
+    if (profile.value.username.length > 20) {
+        profile.value.username = profile.value.username.substring(0, 20);
+    }
+}
+
 async function updateProfile() {
+    // Validation cote client pour le confort de saisie uniquement :
+    // le serveur (PATCH /api/profile/me) revalide et fait foi.
+    const username = profile.value.username.trim();
+    if (username === '') {
+        toastStore.addToast('Le pseudo ne peut pas être vide.', 'error');
+        return;
+    }
+    if (username.length > 20) {
+        toastStore.addToast('Le pseudo ne doit pas dépasser 20 caractères.', 'error');
+        return;
+    }
+
     saving.value = true;
     try {
-        const { error } = await supabase
-            .from('profiles')
-            .upsert({
-                id: user.value.id,
-                username: profile.value.username,
-                avatar_url: profile.value.avatar_url,
-                updated_at: new Date()
-            });
-        
-        if (error) throw error;
+        const response = await fetch(`${API_URL}/api/profile/me`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${authStore.token}`
+            },
+            body: JSON.stringify({
+                username,
+                avatar_url: profile.value.avatar_url
+            })
+        });
+
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Échec de la mise à jour du profil.');
+
+        profile.value = data;
         toastStore.addToast('Profil mis à jour avec succès !');
     } catch (err) {
         console.error('Error updating profile:', err);
-        if (err.code === 'PGRST205') {
-            toastStore.addToast('Table "profiles" introuvable. Veuillez exécuter les scripts SQL.', 'error');
-        } else {
-            toastStore.addToast('Échec de la mise à jour du profil.', 'error');
-        }
+        toastStore.addToast(err.message || 'Échec de la mise à jour du profil.', 'error');
     } finally {
         saving.value = false;
     }
@@ -176,7 +197,8 @@ async function logout() {
                         
                         <div class="form-group">
                             <label class="t-body-text">Nom d'utilisateur</label>
-                            <input v-model="profile.username" type="text" class="input-field" placeholder="Choisis un pseudo">
+                            <input v-model="profile.username" @input="limitUsernameLength" type="text" class="input-field" placeholder="Choisis un pseudo" maxlength="20">
+                            <p class="t-body-text-xs color-text-light u-mt10">{{ profile.username.length }}/20</p>
                         </div>
 
                         <div class="form-group">


### PR DESCRIPTION
La mise a jour du profil se faisait par un upsert Supabase direct depuis le front (cle anon, cote client) : aucune validation serveur ne bornait la taille du username, une requete directe a l'API Supabase pouvait donc contourner n'importe quelle limite posee dans le front.

Ajout d'un vrai point de confiance cote back (controller/service/ repository, meme pattern que le reste du projet) :
- PATCH /api/profile/me (requireAuth) valide et persiste le profil via le client Supabase service-role du back.
- profile.service.js rejette un pseudo vide ou > 20 caracteres avant toute ecriture.
- Dashboard.vue appelle ce endpoint au lieu d'ecrire directement dans Supabase ; la limite/compteur cote front (maxlength, troncature) ne reste qu'un confort de saisie, pas la protection reelle.