### PR TITLE
chore: mettre a jour back/.env.example avec les variables reellement …

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -1,8 +1,17 @@
 PORT=3001
+NODE_ENV=development
 CLIENT_URL=http://localhost:5173
 BACKEND_URL=http://localhost:3001
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+
+# Supabase (service role : acces complet, back uniquement, ne jamais exposer cote client)
 SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
-SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+
+# Spotify (sync admin des playlists : back/services/music.service.js)
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
+SPOTIFY_USER_ID=your_spotify_user_id
+
+# Pas de variable iTunes : back/services/music.service.js#getItunesPreviewUrl
+# appelle l'API de recherche iTunes publique, sans cle.


### PR DESCRIPTION
…utilisees

Verifie contre tous les process.env.* du back :
- Ajout de SPOTIFY_REFRESH_TOKEN et SPOTIFY_USER_ID (lus par music.service.js mais absents du fichier, sync/creation de playlist plantent sans eux) et NODE_ENV (conditionne le bypass CORS en dev).
- Suppression de SUPABASE_JWT_SECRET, qui n'est reference nulle part dans le code (l'auth passe par supabase.auth.getUser(token), pas par une verification JWT manuelle).
- DEEZER_API_BASE non ajoute : a un fallback par defaut et fait partie du dead code Deezer deja identifie pour suppression dans une autre tache.
- front/.env.example verifie separement contre tous les import.meta.env.VITE_* du front : deja exact, aucun changement necessaire.