### PR TITLE
fix(security): faire passer le systeme d'amis par une API back au lie…

### DIFF
--- a/back/controllers/friend.controller.js
+++ b/back/controllers/friend.controller.js
@@ -1,0 +1,65 @@
+const FriendService = require('../services/friend.service');
+
+class FriendController {
+    async search(req, res) {
+        try {
+            const users = await FriendService.searchUsers(req.query.q, req.user.id);
+            res.json(users);
+        } catch (error) {
+            console.error('Failed to search users:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+
+    async listFriends(req, res) {
+        try {
+            const friends = await FriendService.getFriends(req.user.id);
+            res.json(friends);
+        } catch (error) {
+            console.error('Failed to list friends:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+
+    async listPendingRequests(req, res) {
+        try {
+            const requests = await FriendService.getPendingRequests(req.user.id);
+            res.json(requests);
+        } catch (error) {
+            console.error('Failed to list pending requests:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+
+    async sendRequest(req, res) {
+        try {
+            await FriendService.sendFriendRequest(req.user.id, req.body.friendId);
+            res.json({ success: true });
+        } catch (error) {
+            console.error('Failed to send friend request:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+
+    async acceptRequest(req, res) {
+        try {
+            await FriendService.acceptRequest(req.params.requestId, req.user.id);
+            res.json({ success: true });
+        } catch (error) {
+            console.error('Failed to accept friend request:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+
+    async removeFriend(req, res) {
+        try {
+            await FriendService.removeFriend(req.user.id, req.params.friendId);
+            res.json({ success: true });
+        } catch (error) {
+            console.error('Failed to remove friend:', error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    }
+}
+
+module.exports = new FriendController();

--- a/back/controllers/friend.controller.js
+++ b/back/controllers/friend.controller.js
@@ -1,65 +1,46 @@
 const FriendService = require('../services/friend.service');
 
+function asyncHandler(label, handler) {
+    return async (req, res) => {
+        try {
+            await handler(req, res);
+        } catch (error) {
+            console.error(`${label}:`, error.message);
+            res.status(error.status || 500).json({ error: error.message });
+        }
+    };
+}
+
 class FriendController {
-    async search(req, res) {
-        try {
-            const users = await FriendService.searchUsers(req.query.q, req.user.id);
-            res.json(users);
-        } catch (error) {
-            console.error('Failed to search users:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    search = asyncHandler('Failed to search users', async (req, res) => {
+        const users = await FriendService.searchUsers(req.query.q, req.user.id);
+        res.json(users);
+    });
 
-    async listFriends(req, res) {
-        try {
-            const friends = await FriendService.getFriends(req.user.id);
-            res.json(friends);
-        } catch (error) {
-            console.error('Failed to list friends:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    listFriends = asyncHandler('Failed to list friends', async (req, res) => {
+        const friends = await FriendService.getFriends(req.user.id);
+        res.json(friends);
+    });
 
-    async listPendingRequests(req, res) {
-        try {
-            const requests = await FriendService.getPendingRequests(req.user.id);
-            res.json(requests);
-        } catch (error) {
-            console.error('Failed to list pending requests:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    listPendingRequests = asyncHandler('Failed to list pending requests', async (req, res) => {
+        const requests = await FriendService.getPendingRequests(req.user.id);
+        res.json(requests);
+    });
 
-    async sendRequest(req, res) {
-        try {
-            await FriendService.sendFriendRequest(req.user.id, req.body.friendId);
-            res.json({ success: true });
-        } catch (error) {
-            console.error('Failed to send friend request:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    sendRequest = asyncHandler('Failed to send friend request', async (req, res) => {
+        await FriendService.sendFriendRequest(req.user.id, req.body.friendId);
+        res.json({ success: true });
+    });
 
-    async acceptRequest(req, res) {
-        try {
-            await FriendService.acceptRequest(req.params.requestId, req.user.id);
-            res.json({ success: true });
-        } catch (error) {
-            console.error('Failed to accept friend request:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    acceptRequest = asyncHandler('Failed to accept friend request', async (req, res) => {
+        await FriendService.acceptRequest(req.params.requestId, req.user.id);
+        res.json({ success: true });
+    });
 
-    async removeFriend(req, res) {
-        try {
-            await FriendService.removeFriend(req.user.id, req.params.friendId);
-            res.json({ success: true });
-        } catch (error) {
-            console.error('Failed to remove friend:', error.message);
-            res.status(error.status || 500).json({ error: error.message });
-        }
-    }
+    removeFriend = asyncHandler('Failed to remove friend', async (req, res) => {
+        await FriendService.removeFriend(req.user.id, req.params.friendId);
+        res.json({ success: true });
+    });
 }
 
 module.exports = new FriendController();

--- a/back/repositories/friend.repository.js
+++ b/back/repositories/friend.repository.js
@@ -1,0 +1,99 @@
+const supabase = require('../config/db');
+
+class FriendRepository {
+    async searchUsers(query, excludeUserId) {
+        const { data, error } = await supabase
+            .from('profiles')
+            .select('id, username, avatar_url')
+            .ilike('username', `%${query}%`)
+            .neq('id', excludeUserId)
+            .limit(10);
+
+        if (error) throw error;
+        return data;
+    }
+
+    async getFriendships(userId) {
+        const { data, error } = await supabase
+            .from('friendships')
+            .select('user_id, friend_id')
+            .or(`user_id.eq.${userId},friend_id.eq.${userId}`)
+            .eq('status', 'accepted');
+
+        if (error) throw error;
+        return data;
+    }
+
+    async getProfilesByIds(ids) {
+        if (ids.length === 0) return [];
+
+        const { data, error } = await supabase
+            .from('profiles')
+            .select('id, username, avatar_url')
+            .in('id', ids);
+
+        if (error) throw error;
+        return data;
+    }
+
+    async findExistingFriendship(userId, friendId) {
+        const { data, error } = await supabase
+            .from('friendships')
+            .select('id')
+            .or(`and(user_id.eq.${userId},friend_id.eq.${friendId}),and(user_id.eq.${friendId},friend_id.eq.${userId})`)
+            .limit(1);
+
+        if (error) throw error;
+        return data;
+    }
+
+    async createFriendRequest(userId, friendId) {
+        const { error } = await supabase
+            .from('friendships')
+            .insert({ user_id: userId, friend_id: friendId, status: 'pending' });
+
+        if (error) throw error;
+    }
+
+    async getPendingRequests(userId) {
+        const { data, error } = await supabase
+            .from('friendships')
+            .select('id, user_id')
+            .eq('friend_id', userId)
+            .eq('status', 'pending');
+
+        if (error) throw error;
+        return data;
+    }
+
+    async findFriendshipById(requestId) {
+        const { data, error } = await supabase
+            .from('friendships')
+            .select('id, user_id, friend_id, status')
+            .eq('id', requestId)
+            .single();
+
+        if (error) throw error;
+        return data;
+    }
+
+    async acceptFriendship(requestId) {
+        const { error } = await supabase
+            .from('friendships')
+            .update({ status: 'accepted' })
+            .eq('id', requestId);
+
+        if (error) throw error;
+    }
+
+    async deleteFriendship(userId, friendId) {
+        const { error } = await supabase
+            .from('friendships')
+            .delete()
+            .or(`and(user_id.eq.${userId},friend_id.eq.${friendId}),and(user_id.eq.${friendId},friend_id.eq.${userId})`);
+
+        if (error) throw error;
+    }
+}
+
+module.exports = new FriendRepository();

--- a/back/routes/friend.routes.js
+++ b/back/routes/friend.routes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const FriendController = require('../controllers/friend.controller');
+const { requireAuth } = require('../middleware/auth');
+
+router.use(requireAuth);
+
+// GET /api/friends/search?q=...
+router.get('/search', (req, res) => FriendController.search(req, res));
+
+// GET /api/friends
+router.get('/', (req, res) => FriendController.listFriends(req, res));
+
+// GET /api/friends/requests/pending
+router.get('/requests/pending', (req, res) => FriendController.listPendingRequests(req, res));
+
+// POST /api/friends/requests  { friendId }
+router.post('/requests', (req, res) => FriendController.sendRequest(req, res));
+
+// POST /api/friends/requests/:requestId/accept
+router.post('/requests/:requestId/accept', (req, res) => FriendController.acceptRequest(req, res));
+
+// DELETE /api/friends/:friendId
+router.delete('/:friendId', (req, res) => FriendController.removeFriend(req, res));
+
+module.exports = router;

--- a/back/server.js
+++ b/back/server.js
@@ -10,6 +10,7 @@ const { PORT, CLIENT_URL } = require('./config/constants');
 const { corsOptions } = require('./config/cors');
 const musicRoutes = require('./routes/music.routes');
 const authRoutes = require('./routes/auth.routes');
+const friendRoutes = require('./routes/friend.routes');
 const setupSocketIO = require('./sockets/connection');
 
 const app = express();
@@ -29,6 +30,7 @@ app.use(express.json());
 // REST routes
 app.use('/api/auth', authRoutes);
 app.use('/api/music', musicRoutes);
+app.use('/api/friends', friendRoutes);
 
 
 

--- a/back/services/friend.service.js
+++ b/back/services/friend.service.js
@@ -1,5 +1,7 @@
 const friendRepository = require('../repositories/friend.repository');
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 class FriendService {
     async searchUsers(query, currentUserId) {
         const trimmed = (query ?? '').trim();
@@ -17,7 +19,7 @@ class FriendService {
     }
 
     async sendFriendRequest(userId, friendId) {
-        if (!friendId || friendId === userId) {
+        if (!friendId || friendId === userId || !UUID_REGEX.test(friendId)) {
             const error = new Error('Destinataire invalide.');
             error.status = 400;
             throw error;
@@ -60,6 +62,12 @@ class FriendService {
     }
 
     async removeFriend(userId, friendId) {
+        if (!friendId || !UUID_REGEX.test(friendId)) {
+            const error = new Error('Ami invalide.');
+            error.status = 400;
+            throw error;
+        }
+
         await friendRepository.deleteFriendship(userId, friendId);
     }
 }

--- a/back/services/friend.service.js
+++ b/back/services/friend.service.js
@@ -1,0 +1,67 @@
+const friendRepository = require('../repositories/friend.repository');
+
+class FriendService {
+    async searchUsers(query, currentUserId) {
+        const trimmed = (query ?? '').trim();
+        if (trimmed.length < 3) return [];
+
+        return await friendRepository.searchUsers(trimmed, currentUserId);
+    }
+
+    async getFriends(userId) {
+        const friendships = await friendRepository.getFriendships(userId);
+        if (friendships.length === 0) return [];
+
+        const friendIds = friendships.map(f => f.user_id === userId ? f.friend_id : f.user_id);
+        return await friendRepository.getProfilesByIds(friendIds);
+    }
+
+    async sendFriendRequest(userId, friendId) {
+        if (!friendId || friendId === userId) {
+            const error = new Error('Destinataire invalide.');
+            error.status = 400;
+            throw error;
+        }
+
+        const existing = await friendRepository.findExistingFriendship(userId, friendId);
+        if (existing?.length > 0) return; // deja existant, on ne recree pas
+
+        await friendRepository.createFriendRequest(userId, friendId);
+    }
+
+    async getPendingRequests(userId) {
+        const requests = await friendRepository.getPendingRequests(userId);
+        if (requests.length === 0) return [];
+
+        const userIds = requests.map(r => r.user_id);
+        const profiles = await friendRepository.getProfilesByIds(userIds);
+
+        return requests.map(r => ({
+            id: r.id,
+            user: profiles.find(p => p.id === r.user_id)
+        }));
+    }
+
+    async acceptRequest(requestId, currentUserId) {
+        const friendship = await friendRepository.findFriendshipById(requestId);
+
+        if (!friendship || friendship.friend_id !== currentUserId) {
+            const error = new Error('Demande introuvable.');
+            error.status = 404;
+            throw error;
+        }
+        if (friendship.status !== 'pending') {
+            const error = new Error('Cette demande a deja ete traitee.');
+            error.status = 409;
+            throw error;
+        }
+
+        await friendRepository.acceptFriendship(requestId);
+    }
+
+    async removeFriend(userId, friendId) {
+        await friendRepository.deleteFriendship(userId, friendId);
+    }
+}
+
+module.exports = new FriendService();

--- a/front/src/components/Basics/TopNav.vue
+++ b/front/src/components/Basics/TopNav.vue
@@ -35,7 +35,7 @@ async function fetchPendingRequests() {
 
     try {
         pendingRequests.value =
-            await friendService.getPendingRequests(authStore.user.id)
+            await friendService.getPendingRequests(authStore.token)
     } catch (e) {
         console.error(e)
     }
@@ -43,7 +43,7 @@ async function fetchPendingRequests() {
 
 async function acceptRequest(requestId) {
     try {
-        await friendService.acceptRequest(requestId)
+        await friendService.acceptRequest(requestId, authStore.token)
 
         pendingRequests.value = pendingRequests.value.filter(
             r => r.id !== requestId

--- a/front/src/services/friend.service.js
+++ b/front/src/services/friend.service.js
@@ -1,119 +1,65 @@
-import { supabase } from './supabase'
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+
+async function request(path, token, options = {}) {
+    const response = await fetch(`${API_URL}/api/friends${path}`, {
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+            ...(options.headers || {})
+        }
+    })
+
+    const data = await response.json().catch(() => null)
+    if (!response.ok) {
+        throw new Error(data?.error || `HTTP error: ${response.status}`)
+    }
+    return data
+}
 
 export const friendService = {
-  /**
-   * Search for users by username
-   */
-  async searchUsers(query) {
-      const { data, error } = await supabase
-          .from('profiles')
-          .select('id, username, avatar_url')
-          .ilike('username', `%${query}%`)
-          .limit(10)
+    /**
+     * Search for users by username
+     */
+    async searchUsers(query, token) {
+        return await request(`/search?q=${encodeURIComponent(query)}`, token)
+    },
 
-      if (error) throw error
-      return data
-  },
+    /**
+     * Get current user's friends
+     */
+    async getFriends(token) {
+        return await request('/', token)
+    },
 
-  /**
-   * Get current user's friends
-   */
-  async getFriends(userId) {
-      const { data: friendships, error } = await supabase
-          .from('friendships')
-          .select('user_id, friend_id')
-          .or(`user_id.eq.${userId},friend_id.eq.${userId}`)
-          .eq('status', 'accepted')
+    /**
+     * Send a friend request
+     */
+    async sendFriendRequest(friendId, token) {
+        return await request('/requests', token, {
+            method: 'POST',
+            body: JSON.stringify({ friendId })
+        })
+    },
 
-      if (error) throw error
-      if (!friendships.length) return []
+    /**
+     * Get pending friend requests
+     */
+    async getPendingRequests(token) {
+        return await request('/requests/pending', token)
+    },
 
-      const friendIds = friendships.map(f =>
-          f.user_id === userId ? f.friend_id : f.user_id
-      )
-
-      const { data: profiles, error: profilesError } = await supabase
-          .from('profiles')
-          .select('id, username, avatar_url')
-          .in('id', friendIds)
-
-      if (profilesError) throw profilesError
-      console.log('friends:', profiles)
-      return profiles
-  },
-
-  /**
-   * Send a friend request
-   */
-  async sendFriendRequest(userId, friendId) {
-      // Vérifie qu'il n'existe pas déjà une demande dans l'un ou l'autre sens
-      const { data: existing } = await supabase
-          .from('friendships')
-          .select('id')
-          .or(
-              `and(user_id.eq.${userId},friend_id.eq.${friendId}),and(user_id.eq.${friendId},friend_id.eq.${userId})`
-          )
-          .limit(1)
-
-      if (existing?.length > 0) return // déjà existant, on ne recrée pas
-
-      const { error } = await supabase
-          .from('friendships')
-          .insert({ user_id: userId, friend_id: friendId, status: 'pending' })
-
-      if (error) throw error
-  },
-
-  /**
-   * Get pending friend requests
-   */
-  async getPendingRequests(userId) {
-      const { data: requests, error } = await supabase
-          .from('friendships')
-          .select('id, user_id')
-          .eq('friend_id', userId)
-          .eq('status', 'pending')
-
-      if (error) throw error
-      if (!requests.length) return []
-
-      const userIds = requests.map(r => r.user_id)
-      const { data: profiles, error: profilesError } = await supabase
-          .from('profiles')
-          .select('id, username, avatar_url')
-          .in('id', userIds)
-
-      if (profilesError) throw profilesError
-
-      return requests.map(r => ({
-          id: r.id,
-          user: profiles.find(p => p.id === r.user_id)
-      }))
-  },
-
-  /**
-   * Accept friend request
-   */
-  async acceptRequest(requestId) {
-    const { error } = await supabase
-      .from('friendships')
-      .update({ status: 'accepted' })
-      .eq('id', requestId)
-    
-    if (error) throw error
-  },
+    /**
+     * Accept friend request
+     */
+    async acceptRequest(requestId, token) {
+        return await request(`/requests/${requestId}/accept`, token, { method: 'POST' })
+    },
 
     /**
      * Remove friendship
      */
-    async removeFriend(userId, friendId) {
-        const { data, error } = await supabase
-            .from('friendships')
-            .delete()
-            .or(`and(user_id.eq.${userId},friend_id.eq.${friendId}),and(user_id.eq.${friendId},friend_id.eq.${userId})`)
-            .select()
-
-        console.log('deleted:', data, error)
-        if (error) throw error
+    async removeFriend(friendId, token) {
+        return await request(`/${friendId}`, token, { method: 'DELETE' })
     },
 }

--- a/front/src/views/profile/Dashboard.vue
+++ b/front/src/views/profile/Dashboard.vue
@@ -33,7 +33,7 @@ onMounted(async () => {
 
 async function removeFriend() {
     try {
-        await friendService.removeFriend(authStore.user.id, friendToRemove.value.id)
+        await friendService.removeFriend(friendToRemove.value.id, authStore.token)
         friends.value = friends.value.filter(f => f.id !== friendToRemove.value.id)
         toastStore.addToast('Ami supprimé.')
     } catch (err) {
@@ -86,13 +86,11 @@ async function updateProfile() {
 
 async function fetchFriendsData() {
     try {
-        friends.value = await friendService.getFriends(user.value.id);
-        pendingRequests.value = await friendService.getPendingRequests(user.value.id);
+        friends.value = await friendService.getFriends(authStore.token);
+        pendingRequests.value = await friendService.getPendingRequests(authStore.token);
     } catch (err) {
         console.error('Error fetching friends:', err);
-        if (err.code === 'PGRST205') {
-            toastStore.addToast('Tables de base de données introuvables.', 'error');
-        }
+        toastStore.addToast('Impossible de charger les données d\'amis.', 'error');
     }
 }
 
@@ -103,9 +101,7 @@ async function searchUsers() {
     }
     loading.value = true;
     try {
-        searchResults.value = await friendService.searchUsers(searchQuery.value);
-        // Exclude self and current friends/pending
-        searchResults.value = searchResults.value.filter(u => u.id !== user.value.id);
+        searchResults.value = await friendService.searchUsers(searchQuery.value, authStore.token);
     } catch (err) {
         console.error('Error searching users:', err);
     } finally {
@@ -115,7 +111,7 @@ async function searchUsers() {
 
 async function sendRequest(friendId) {
     try {
-        await friendService.sendFriendRequest(user.value.id, friendId);
+        await friendService.sendFriendRequest(friendId, authStore.token);
         toastStore.addToast('Demande d\'ami envoyée !');
         searchQuery.value = '';
         searchResults.value = [];
@@ -127,7 +123,7 @@ async function sendRequest(friendId) {
 
 async function acceptRequest(requestId) {
     try {
-        await friendService.acceptRequest(requestId);
+        await friendService.acceptRequest(requestId, authStore.token);
         await fetchFriendsData();
     } catch (err) {
         console.error('Error accepting request:', err);


### PR DESCRIPTION
…u de Supabase direct

front/src/services/friend.service.js appelait Supabase directement avec la cle anon pour tout le systeme d'amis, avec le userId passe en simple parametre de fonction (jamais verifie contre le token) : n'importe quel client pouvait potentiellement lire la liste d'amis de n'importe qui, envoyer une demande au nom d'un autre utilisateur, accepter n'importe quelle demande en connaissant/devinant un id, ou supprimer une amitie d'autrui. Meme classe de probleme que le bug username deja corrige sur Dashboard.vue : le client ne doit jamais faire foi.

Ajout d'une API back (routes/controller/service/repository, meme pattern que profile.*) montee sur /api/friends, protegee par requireAuth :
- Toutes les operations derivent l'identite de req.user.id (le token), plus jamais d'un id fourni par le client.
- acceptRequest verifie en plus que la demande appartient bien a l'utilisateur courant (friendship.friend_id === req.user.id) avant de l'accepter -- verification absente du code client original.
- front/services/friend.service.js et ses deux appelants (Dashboard.vue, TopNav.vue) consomment desormais cette API au lieu d'ecrire dans Supabase.