### PR TITLE
fix: reappliquer le correctif manque de la PR #9 (validation profil)

### DIFF
--- a/back/services/profile.service.js
+++ b/back/services/profile.service.js
@@ -1,10 +1,17 @@
 const profileRepository = require('../repositories/profile.repository');
 
 const USERNAME_MAX_LENGTH = 20;
+const AVATAR_URL_MAX_LENGTH = 2048;
 
 class ProfileService {
     async updateProfile(userId, { username, avatar_url }) {
-        const trimmedUsername = (username ?? '').trim();
+        if (typeof username !== 'string') {
+            const error = new Error('Le pseudo doit être une chaîne de caractères.');
+            error.status = 400;
+            throw error;
+        }
+
+        const trimmedUsername = username.trim();
 
         if (trimmedUsername === '') {
             const error = new Error('Le pseudo ne peut pas être vide.');
@@ -13,6 +20,11 @@ class ProfileService {
         }
         if (trimmedUsername.length > USERNAME_MAX_LENGTH) {
             const error = new Error(`Le pseudo ne doit pas dépasser ${USERNAME_MAX_LENGTH} caractères.`);
+            error.status = 400;
+            throw error;
+        }
+        if (avatar_url != null && (typeof avatar_url !== 'string' || avatar_url.length > AVATAR_URL_MAX_LENGTH)) {
+            const error = new Error("L'URL de l'avatar est invalide.");
             error.status = 400;
             throw error;
         }

--- a/front/src/services/profile.service.js
+++ b/front/src/services/profile.service.js
@@ -1,0 +1,19 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+export const profileService = {
+    async updateProfile(token, { username, avatar_url }) {
+        const response = await fetch(`${API_URL}/api/profile/me`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify({ username, avatar_url })
+        });
+
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Échec de la mise à jour du profil.');
+
+        return data;
+    }
+};

--- a/front/src/views/profile/Dashboard.vue
+++ b/front/src/views/profile/Dashboard.vue
@@ -2,11 +2,11 @@
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { friendService } from '@/services/friend.service';
+import { profileService } from '@/services/profile.service';
 import ParticleBackground from "@/components/Basics/ParticleBackground.vue";
 import { ref, onMounted, computed } from 'vue';
 import { supabase } from '@/services/supabase';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 const authStore = useAuthStore();
 const toastStore = useToastStore();
 const user = computed(() => authStore.user);
@@ -59,12 +59,6 @@ async function fetchProfile() {
     }
 }
 
-function limitUsernameLength() {
-    if (profile.value.username.length > 20) {
-        profile.value.username = profile.value.username.substring(0, 20);
-    }
-}
-
 async function updateProfile() {
     // Validation cote client pour le confort de saisie uniquement :
     // le serveur (PATCH /api/profile/me) revalide et fait foi.
@@ -80,20 +74,10 @@ async function updateProfile() {
 
     saving.value = true;
     try {
-        const response = await fetch(`${API_URL}/api/profile/me`, {
-            method: 'PATCH',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${authStore.token}`
-            },
-            body: JSON.stringify({
-                username,
-                avatar_url: profile.value.avatar_url
-            })
+        const data = await profileService.updateProfile(authStore.token, {
+            username,
+            avatar_url: profile.value.avatar_url
         });
-
-        const data = await response.json();
-        if (!response.ok) throw new Error(data.error || 'Échec de la mise à jour du profil.');
 
         profile.value = data;
         toastStore.addToast('Profil mis à jour avec succès !');
@@ -197,7 +181,7 @@ async function logout() {
                         
                         <div class="form-group">
                             <label class="t-body-text">Nom d'utilisateur</label>
-                            <input v-model="profile.username" @input="limitUsernameLength" type="text" class="input-field" placeholder="Choisis un pseudo" maxlength="20">
+                            <input v-model="profile.username" type="text" class="input-field" placeholder="Choisis un pseudo" maxlength="20">
                             <p class="t-body-text-xs color-text-light u-mt10">{{ profile.username.length }}/20</p>
                         </div>
 


### PR DESCRIPTION
## Contexte

Le correctif poussé sur la branche de la PR #9 (validation `username`/`avatar_url` côté serveur + alignement front sur le pattern service) est arrivé une minute après le merge de cette PR dans `develop`. Le code mergé ne contenait donc que la version initiale, sans le correctif.

## Contenu

- `back/services/profile.service.js` : rejette un `username` non-string avant `.trim()` (évitait un 500 brut au lieu du 400 attendu), valide type/longueur d'`avatar_url`.
- `front/src/services/profile.service.js` (nouveau) : extrait l'appel `PATCH /api/profile/me`, suivant le pattern déjà utilisé par `auth.service.js` / `friend.service.js`.
- `front/src/views/profile/Dashboard.vue` : utilise ce nouveau service, supprime le handler `limitUsernameLength` redondant avec `maxlength="20"`.

Note : le correctif de la PR #12 (fondu audio) est arrivé à temps et est déjà présent dans `develop` — rien à refaire de ce côté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)