### PR TITLE
fix: aligner l'affichage du jeu sur le schema Supabase

### DIFF
--- a/front/src/components/Blindtest/Game/Guessing.vue
+++ b/front/src/components/Blindtest/Game/Guessing.vue
@@ -123,7 +123,7 @@ function getPlayerColor(index) {
     <!-- Audio caché -->
     <audio
       ref="audioEl"
-      :src="musicToGuess.preview"
+      :src="musicToGuess.preview_url"
       autoplay
       @play="onPlay"
       @timeupdate="onTimeUpdate"

--- a/front/src/components/Blindtest/Game/ModalRoundOver.vue
+++ b/front/src/components/Blindtest/Game/ModalRoundOver.vue
@@ -51,12 +51,12 @@ function getRoundScore(player) {
     <!-- Révélation de la chanson -->
     <div class="song-reveal-container">
         <div class="album-art-wrapper">
-            <img :src="musicToGuess.album?.cover_xl" class="album-art-bg" />
-            <img :src="musicToGuess.album?.cover_medium" class="album-art" />
+            <img :src="musicToGuess.cover_url" class="album-art-bg" />
+            <img :src="musicToGuess.cover_url" class="album-art" />
         </div>
         <div class="song-info-reveal">
-            <h2 class="song-title">{{ musicToGuess.title_short }}</h2>
-            <p class="song-artist">{{ musicToGuess.artist?.name }}</p>
+            <h2 class="song-title">{{ musicToGuess.title }}</h2>
+            <p class="song-artist">{{ musicToGuess.artist }}</p>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Le backend renvoie un schema plat depuis la migration Supabase (`title`, `artist` string, `cover_url`, `preview_url`) mais `Guessing.vue` et `ModalRoundOver.vue` consommaient encore l'ancien schema imbrique Deezer.
- Consequence en jeu : les rounds se lancaient mais aucun son ne jouait (`musicToGuess.preview` undefined) et aucune reponse ne s'affichait en fin de round (`album.cover_xl`, `title_short`, `artist.name` tous undefined).
- Correction des bindings pour utiliser les champs reellement renvoyes par `MusicService.GetPlaylistDetails` (`preview_url`, `cover_url`, `title`, `artist`).

## Test plan
- [x] Verifie que `back/services/game.service.js#startGame` renvoie bien ces champs (deja migre vers `GetPlaylistDetails`)
- [x] Verifie qu'aucun autre composant actif ne consomme l'ancien schema (`Playing-delete.vue` est du code mort, hors scope, deja trackee separement)
- [ ] A tester manuellement en partie reelle : lecture audio pendant le round + affichage titre/artiste/pochette en fin de round

Lie a la tache Notion "Finir de migrer le moteur de jeu vers l'archi Supabase".

🤖 Generated with [Claude Code](https://claude.com/claude-code)