### PR TITLE
fix: empecher le crash de startGame sans categorie selectionnee

### DIFF
--- a/back/services/game.service.js
+++ b/back/services/game.service.js
@@ -11,6 +11,10 @@ class GameService {
         const category = room.setting.category;
         const nbMusics = room.setting.songCount;
 
+        if (!category) {
+            throw new Error('Aucune catégorie sélectionnée.');
+        }
+
         const playlistDetails = await MusicService.GetPlaylistDetails(category.id);
 
         // Shuffle and take required number

--- a/back/sockets/modes/classic.handlers.js
+++ b/back/sockets/modes/classic.handlers.js
@@ -3,9 +3,13 @@ const gameService = require('../../services/game.service');
 
 module.exports = (io, socket) => {
     socket.on('startGame', async (roomId) => {
-        const room = await gameService.startGame(roomId, roomService)
-        if (room) {
-            await playNextRound(roomId, io, roomService, gameService)
+        try {
+            const room = await gameService.startGame(roomId, roomService)
+            if (room) {
+                await playNextRound(roomId, io, roomService, gameService)
+            }
+        } catch (error) {
+            socket.emit('error', error.message);
         }
     });
 

--- a/front/src/components/Blindtest/Room/Utils/RoomSettings.vue
+++ b/front/src/components/Blindtest/Room/Utils/RoomSettings.vue
@@ -2,12 +2,15 @@
 import socket from "@/utils/socket.js";
 import { useRouter } from "vue-router";
 import { usePlayerStore} from "@/stores/playerStore.js";
+import { useToastStore } from "@/stores/toastStore.js";
 import { computed, onMounted, ref, watch} from "vue";
 import PlayerList from "@/components/Blindtest/Room/Utils/PlayerList.vue";
 
 const playerStore = usePlayerStore()
+const toastStore = useToastStore()
 const router = useRouter()
 const room = computed(() => playerStore.room);
+const canStartGame = computed(() => !!playerStore.room.setting?.category);
 const currentPlayer = computed(() =>
     playerStore.room.players.find(player => player.socketId === socket.id)
 )
@@ -44,6 +47,11 @@ onMounted(() => {
     socket.off("gameStarted")
     socket.on('gameStarted', (room) => {
         playerStore.startGame(room)
+    })
+
+    socket.off("error")
+    socket.on('error', (message) => {
+        toastStore.addToast(message, 'error')
     })
 })
 
@@ -96,7 +104,13 @@ onMounted(() => {
             </div>
 
             <div class="w100 u-flex u-justify-content-center u-align-items-center u-pt10">
-                <button v-if="currentPlayer.host" @click="socket.emit('startGame', room.id);" class="btn-primary start-button">
+                <button
+                    v-if="currentPlayer.host"
+                    @click="socket.emit('startGame', room.id);"
+                    :disabled="!canStartGame"
+                    :title="canStartGame ? '' : 'Select a category first'"
+                    class="btn-primary start-button"
+                >
                     Start Blindtest
                 </button>
                 <div v-else class="waiting-indicator u-flex u-align-items-center u-gap10">


### PR DESCRIPTION
## Summary
- `room.setting.category` vaut `null` par defaut (`room.service.js:12`). Si l'hote clique sur "Start Blindtest" sans avoir choisi de categorie, `game.service.js#startGame` faisait `category.id` sans garde -> exception non geree cote serveur, round jamais lance, aucun retour au joueur.
- Ajout d'une garde qui leve une erreur explicite, propagee au client via l'event `error` existant (meme pattern que `room.handlers.js#joinRoom`).
- Cote front, le bouton Start est desormais desactive tant qu'aucune categorie n'est selectionnee (fix principal, evite le cas d'usage), et un toast affiche le message d'erreur si le cas survient quand meme (defense en profondeur, ex: autre client/version).

## Test plan
- [ ] Lancer une room, ne pas selectionner de categorie, cliquer Start -> bouton desactive
- [ ] Selectionner une categorie -> bouton actif, partie demarre normalement
- [ ] (optionnel) forcer un `socket.emit('startGame', roomId)` sans categorie via la console -> toast d'erreur affiche, serveur ne crashe pas

Lie a la tache Notion "game.service.js#startGame plante si aucune categorie n'est selectionnee".

🤖 Generated with [Claude Code](https://claude.com/claude-code)