### PR TITLE
fix: resoudre le Network error sur la sauvegarde du dashboard

### DIFF
--- a/back/config/cors.js
+++ b/back/config/cors.js
@@ -1,8 +1,12 @@
+const { CLIENT_URL } = require('./constants');
+
+// CLIENT_URL est la source de verite pour l'origine de production (meme
+// variable d'env que celle utilisee par Socket.IO dans server.js). Les
+// origines localhost restent autorisees pour le dev.
 const allowedOrigins = [
-    'http://localhost:5173', // Dev frontend
-    'http://127.0.0.1:5173', // Alternative localhost
-    'https://votre-domaine.com', // Production
-    'https://www.votre-domaine.com' // WWW
+    CLIENT_URL,
+    'http://localhost:5173',
+    'http://127.0.0.1:5173'
 ];
 
 const corsOptions = {

--- a/back/server.js
+++ b/back/server.js
@@ -34,7 +34,15 @@ app.use('/api/music', musicRoutes);
 app.use('/api/friends', friendRoutes);
 app.use('/api/profile', profileRoutes);
 
-
+// Middleware d'erreur global : sans lui, une erreur (CORS refuse, body
+// trop volumineux, JSON malforme...) remonte sous forme de page HTML ou
+// de coupure de connexion brute plutot qu'une reponse JSON exploitable
+// par le front.
+app.use((err, req, res, next) => {
+    console.error(err);
+    const status = err.status || (err.type === 'entity.too.large' ? 413 : 500);
+    res.status(status).json({ error: err.message || 'Erreur serveur.' });
+});
 
 httpServer.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/front/src/services/profile.service.js
+++ b/front/src/services/profile.service.js
@@ -2,16 +2,21 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 export const profileService = {
     async updateProfile(token, { username, avatar_url }) {
-        const response = await fetch(`${API_URL}/api/profile/me`, {
-            method: 'PATCH',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`
-            },
-            body: JSON.stringify({ username, avatar_url })
-        });
+        let response;
+        try {
+            response = await fetch(`${API_URL}/api/profile/me`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`
+                },
+                body: JSON.stringify({ username, avatar_url })
+            });
+        } catch {
+            throw new Error('Impossible de contacter le serveur. Vérifiez votre connexion et réessayez.');
+        }
 
-        const data = await response.json();
+        const data = await response.json().catch(() => ({}));
         if (!response.ok) throw new Error(data.error || 'Échec de la mise à jour du profil.');
 
         return data;


### PR DESCRIPTION
## Summary
- `back/config/cors.js` listait des origines codees en dur avec des placeholders jamais remplaces (`https://votre-domaine.com`), desynchronisees de `CLIENT_URL` deja utilisee par Socket.IO dans `server.js`. Hors localhost, le preflight CORS bloquait toute requete REST (dont la sauvegarde de profil), ce qui remonte cote navigateur comme "NetworkError when attempting to fetch resource" -- un message generique sans piste d'action.
- `cors.js` derive maintenant `allowedOrigins` de `CLIENT_URL` (meme source de verite que Socket.IO), tout en gardant `localhost:5173` / `127.0.0.1:5173` pour le dev.
- Ajout d'un middleware d'erreur Express global dans `server.js` : sans lui, une erreur (CORS refuse, JSON malforme, payload trop volumineux) remontait sous forme de page HTML ou de coupure de connexion brute plutot qu'une reponse JSON exploitable.
- `front/src/services/profile.service.js` distingue desormais un vrai echec reseau (le `fetch` lui-meme rejette) d'une erreur metier renvoyee par l'API, avec un message actionnable.

## Test plan
- [ ] Verifier que la sauvegarde du profil fonctionne toujours en local (`CLIENT_URL=http://localhost:5173`)
- [ ] Configurer `CLIENT_URL` avec le domaine de prod reel et verifier que la sauvegarde fonctionne (plus de blocage CORS)
- [ ] Simuler un serveur injoignable (backend coupe) et verifier que le message d'erreur front est clair au lieu du "Network error" brut

Lie a la tache Notion "Dashboard : Network error when attempting to fetch resource lors de l'enregistrement du profil".

🤖 Generated with [Claude Code](https://claude.com/claude-code)